### PR TITLE
新しいディレクトリ構成に配置したHTMLにルーティングする

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,2 @@
+# kanazawa_1st
+/special/kanazawa_1st/index.html /src/pages/kanazawa_1st/index.html

--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,2 @@
 # kanazawa_1st
-/special/kanazawa_1st/index.html /src/pages/kanazawa_1st/index.html
+/special/kanazawa_1st/ /src/pages/kanazawa_1st/

--- a/special/kanazawa_1st/index.html
+++ b/special/kanazawa_1st/index.html
@@ -6,6 +6,10 @@
   SNS などのリンクから遷移する可能性があるのでページは残しておく
 -->
 
+<!-- 
+  old page
+ -->
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src/pages/_root/index.html
+++ b/src/pages/_root/index.html
@@ -73,7 +73,7 @@
         <li>
           <a
             class="page-link"
-            href="../count/index.html"
+            href="../count/"
           >
             <span>連打筋を鍛える</span>
             <!-- ArrowRight Icon -->
@@ -83,7 +83,7 @@
         <li>
           <a
             class="page-link"
-            href="../draw/index.html"
+            href="../draw/"
           >
             <span>運を手繰り寄せる</span>
             <!-- ArrowRight Icon -->
@@ -93,7 +93,7 @@
         <li>
           <a
             class="page-link"
-            href="../fire/index.html"
+            href="../fire/"
           >
             <span>反射神経を爆上げする</span>
             <!-- ArrowRight Icon -->
@@ -103,7 +103,7 @@
         <li>
           <a
             class="page-link"
-            href="../bomber/index.html"
+            href="../bomber/"
           >
             <span>スワイプの感覚を掴む</span>
             <!-- ArrowRight Icon -->
@@ -113,7 +113,7 @@
         <li>
           <a
             class="page-link"
-            href="../dress/index.html"
+            href="../dress/"
           >
             <span>山札を掌握する</span>
             <!-- ArrowRight Icon -->

--- a/src/pages/kanazawa_1st/index.html
+++ b/src/pages/kanazawa_1st/index.html
@@ -18,7 +18,7 @@
   <meta name="description" content="ハロめぐー！">
   <link rel="icon" href="../../assets/favicon.ico">
   <link rel="stylesheet" href="https://unpkg.com/ress/dist/ress.min.css">
-  <link rel="stylesheet" href="../../style.css">
+  <link rel="stylesheet" href="../../global.css">
   <link rel="stylesheet" href="./style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -32,7 +32,7 @@
 
     gtag('config', 'G-0LRB16S0GH');
   </script>
-  <script src="../../script.js"></script>
+  <script src="./script.js"></script>
   <title>看板ハロめぐ総選挙 | めぐ島</title>
 </head>
 <body>
@@ -50,10 +50,10 @@
 
   -->
   <header>
-    <nav class="breadcrumb">
-      <a href="../../index.html">
+    <nav class="c-breadcrumb">
+      <a href="../../pages/_root/index.html">
         <!-- ChevronLeft Icon -->
-        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="currentColor" d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l192 192c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L77.3 256 246.6 86.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-192 192z"/></svg>
+        <svg class="c-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="currentColor" d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l192 192c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L77.3 256 246.6 86.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-192 192z"/></svg>
         <span>めぐ島🏝️</span>
       </a>
     </nav>
@@ -62,10 +62,10 @@
     </h1>
   </header>
   <main>
-    <div class="container">
+    <div class="c-container">
       <img
         src="../../assets/logo-pressed.png"
-        class="logo"
+        class="c-logo"
         onclick="hellomeg(this)"
       >
     </div>
@@ -112,7 +112,7 @@
       target="_blank"
     >
       <!-- Twiiter Icon -->
-      <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="currentColor" d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/></svg>
+      <svg class="c-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="currentColor" d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/></svg>
       <span>投票を呼びかける</span>
     </a>
   </footer>

--- a/src/pages/kanazawa_1st/index.html
+++ b/src/pages/kanazawa_1st/index.html
@@ -51,7 +51,7 @@
   -->
   <header>
     <nav class="c-breadcrumb">
-      <a href="../../pages/_root/index.html">
+      <a href="../_root/index.html">
         <!-- ChevronLeft Icon -->
         <svg class="c-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="currentColor" d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l192 192c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L77.3 256 246.6 86.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-192 192z"/></svg>
         <span>めぐ島🏝️</span>

--- a/src/pages/kanazawa_1st/script.js
+++ b/src/pages/kanazawa_1st/script.js
@@ -1,0 +1,33 @@
+const TEXT_HELLOMEG = "ハロめぐー！";
+
+/**
+ * ロゴからハロめぐー！をランダムな方向に射出する
+ */
+const hellomeg = (e) => {
+  // ロゴを揺らす
+  e.classList.add("shake-img");
+  setTimeout(() => {
+    e.classList.remove("shake-img");
+  }, 300);
+
+  const hellomegElement = document.createElement("div");
+  hellomegElement.textContent = TEXT_HELLOMEG;
+  hellomegElement.classList.add("hellomeg");
+
+  // container の中心から外側に向かってランダムに飛び出す
+  const randomAngle = Math.random() * 2 * Math.PI;
+  const translateX = Math.cos(randomAngle) * 180;
+  const translateY = Math.sin(randomAngle) * 180;
+  hellomegElement.style.setProperty("--translateX", translateX + "px");
+  hellomegElement.style.setProperty("--translateY", translateY + "px");
+  hellomegElement.style.setProperty("--startX", Math.cos(randomAngle) * 20 + "%");
+  hellomegElement.style.setProperty("--startY", Math.sin(randomAngle) * 20 + "%");
+
+  const container = document.querySelector(".c-container");
+  container.appendChild(hellomegElement);
+
+  // animation 完了後に要素を削除する
+  setTimeout(() => {
+    hellomegElement.remove();
+  }, 2000);
+}

--- a/src/pages/kanazawa_1st/style.css
+++ b/src/pages/kanazawa_1st/style.css
@@ -1,0 +1,35 @@
+@keyframes hellomegAnimation {
+  0% {
+    transform: translate(calc(-50% + var(--startX)), calc(-50% + var(--startY))) scale(1);
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
+  100% {
+    transform: translate(calc(-50% + var(--translateX)), calc(-50% + var(--translateY)));
+    opacity: 0;
+  }
+}
+
+.hellomeg {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-drag: none;
+  animation: hellomegAnimation 2s ease-out;
+}
+
+@keyframes shakeAnimation {
+  0% { transform: rotate(0); }
+  25% { transform: rotate(5deg); }
+  50% { transform: rotate(0); }
+  75% { transform: rotate(-5deg); }
+  100% { transform: rotate(0); }
+}
+
+.shake-img {
+  animation: shakeAnimation 0.3s ease;
+}


### PR DESCRIPTION
## 目的
https://github.com/mtsml/kiaiiretekonchikushow/pull/42 の積み残し。

## 修正内容
_redirects ファイルを使ってルーティングする。

## チェック
- [] 既存のパスがすべてこれまで通りのコンテンツにルーティングされる

## 参考
- https://github.com/mtsml/kiaiiretekonchikushow/pull/42
- https://developers.cloudflare.com/pages/configuration/redirects/