### PR TITLE
ハロめぐガチャのレイアウト修正

### DIFF
--- a/src/pages/gacha_hellomegu/index.html
+++ b/src/pages/gacha_hellomegu/index.html
@@ -109,6 +109,15 @@
         </button>
       </p>
       <p>
+        <button
+          id="copy-button"
+        >
+          <!-- Copy Icon -->
+          <svg class="c-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="currentColor" d="M384 336l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L400 115.9 400 320c0 8.8-7.2 16-16 16zM192 384l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1L192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-32-48 0 0 32c0 8.8-7.2 16-16 16L64 464c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l32 0 0-48-32 0z"/></svg>
+          <span>ガチャ結果をクリップボードにコピー</span>
+        </button>
+      </p>
+      <p>
         <button onclick="location.reload()">
           <!-- Reload Icon -->
           <svg class="c-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="currentColor" d="M463.5 224H472c13.3 0 24-10.7 24-24V72c0-9.7-5.8-18.5-14.8-22.2s-19.3-1.7-26.2 5.2L413.4 96.6c-87.6-86.5-228.7-86.2-315.8 1c-87.5 87.5-87.5 229.3 0 316.8s229.3 87.5 316.8 0c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0c-62.5 62.5-163.8 62.5-226.3 0s-62.5-163.8 0-226.3c62.2-62.2 162.7-62.5 225.3-1L327 183c-6.9 6.9-8.9 17.2-5.2 26.2s12.5 14.8 22.2 14.8H463.5z"/></svg>

--- a/src/pages/gacha_hellomegu/index.html
+++ b/src/pages/gacha_hellomegu/index.html
@@ -101,7 +101,6 @@
         </a>      
         <button
           id="share-button"
-          onclick="share()"
           style="display: none;"
         >
           <!-- Share Icon -->

--- a/src/pages/gacha_hellomegu/index.html
+++ b/src/pages/gacha_hellomegu/index.html
@@ -109,15 +109,6 @@
         </button>
       </p>
       <p>
-        <button
-          id="copy-button"
-        >
-          <!-- Copy Icon -->
-          <svg class="c-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="currentColor" d="M384 336l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L400 115.9 400 320c0 8.8-7.2 16-16 16zM192 384l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1L192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-32-48 0 0 32c0 8.8-7.2 16-16 16L64 464c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l32 0 0-48-32 0z"/></svg>
-          <span>ガチャ結果をクリップボードにコピー</span>
-        </button>
-      </p>
-      <p>
         <button onclick="location.reload()">
           <!-- Reload Icon -->
           <svg class="c-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="currentColor" d="M463.5 224H472c13.3 0 24-10.7 24-24V72c0-9.7-5.8-18.5-14.8-22.2s-19.3-1.7-26.2 5.2L413.4 96.6c-87.6-86.5-228.7-86.2-315.8 1c-87.5 87.5-87.5 229.3 0 316.8s229.3 87.5 316.8 0c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0c-62.5 62.5-163.8 62.5-226.3 0s-62.5-163.8 0-226.3c62.2-62.2 162.7-62.5 225.3-1L327 183c-6.9 6.9-8.9 17.2-5.2 26.2s12.5 14.8 22.2 14.8H463.5z"/></svg>

--- a/src/pages/gacha_hellomegu/script.js
+++ b/src/pages/gacha_hellomegu/script.js
@@ -114,9 +114,10 @@ const startHellomegGacha = (hellomegImgElement) => {
   }, animationDelayBase * 1000);
 
   // すべてのカードを描画し終わったら周回完了として非表示にする
+  // 加算している 0.7 s は rotateAroundCircle の 50%-100% の変化にかかる時間
   setTimeout(() => {
     firstImg.style.display = 'none';
-  }, totalAnimationDuration * 1000);
+  }, (totalAnimationDuration + 0.7) * 1000);
 
   const radius = 30;
   // カードの円を secretCardContainer の中央に配置するためのオフセット

--- a/src/pages/gacha_hellomegu/script.js
+++ b/src/pages/gacha_hellomegu/script.js
@@ -239,6 +239,24 @@ const displayShareButtonOrTweetLink = (cards) => {
       throw error;
     }
   }
+
+  // TODO: クリップボードにコピーを試してみる
+  document.getElementById("copy-button").onclick = () => {
+    canvas.toBlob((blob) => {
+      const data = [new ClipboardItem({ [blob.type]: blob })];
+
+      navigator.clipboard.write(data).then(
+        () => {
+          /* success */
+          alert('success')
+        },
+        (error) => {
+          /* failure */
+          alert(error)
+        },
+      );
+    });
+  }
 }
 
 /**

--- a/src/pages/gacha_hellomegu/script.js
+++ b/src/pages/gacha_hellomegu/script.js
@@ -106,11 +106,14 @@ const startHellomegGacha = (hellomegImgElement) => {
   firstImg.style.backgroundColor = 'cyan';
   secretCardContainer.appendChild(firstImg);
 
-  const firstAngle = 0;
   const radius = 30;
-  const offset = 10;
-  const x = 175 + (radius - offset) * Math.cos(firstAngle);
-  const y = 175 + (radius - offset) * Math.sin(firstAngle);
+  // カードの円を secretCardContainer の中央に配置するためのオフセット
+  const offsetX = 90;
+  const offsetY = 60;
+
+  const firstAngle = 0;
+  const x = offsetX + radius * Math.cos(firstAngle);
+  const y = offsetY + radius * Math.sin(firstAngle);
 
   firstImg.style.left = `${x}px`;
   firstImg.style.top = `${y}px`;
@@ -124,12 +127,11 @@ const startHellomegGacha = (hellomegImgElement) => {
     secretCardContainer.appendChild(img);
 
     const angle = (i * 36) * (Math.PI / 180);
-    const x = 175 + (radius - offset) * Math.cos(angle);
-    const y = 175 + (radius - offset) * Math.sin(angle);
+    const x = offsetX + radius * Math.cos(angle);
+    const y = offsetY + radius * Math.sin(angle);
 
     img.style.left = `${x}px`;
     img.style.top = `${y}px`;
-
     img.style.transform = `rotate(${angle}rad) translate(0, -50%)`;
     img.style.animationDelay = `${i * 0.06 + 1}s`;
   }

--- a/src/pages/gacha_hellomegu/script.js
+++ b/src/pages/gacha_hellomegu/script.js
@@ -51,11 +51,9 @@ const viewModal = (hellomegImgElement) => {
     modalOverlay.style.display = "none";
   };
 
-  window.onclick = function(event) {
-    if (event.target == modal) {
-      modal.style.display = "none";
-      modalOverlay.style.display = "none";
-    }
+  // モーダル本体をクリックしても閉じないようにする
+  modal.onclick = function(e) {
+    e.stopPropagation();
   };
 };
 
@@ -114,10 +112,10 @@ const startHellomegGacha = (hellomegImgElement) => {
   }, animationDelayBase * 1000);
 
   // すべてのカードを描画し終わったら周回完了として非表示にする
-  // 加算している 0.7 s は rotateAroundCircle の 50%-100% の変化にかかる時間
+  // 加算している 0.1 s はいい感じの delay
   setTimeout(() => {
     firstImg.style.display = 'none';
-  }, (totalAnimationDuration + 0.7) * 1000);
+  }, (totalAnimationDuration + 0.1) * 1000);
 
   const radius = 30;
   // カードの円を secretCardContainer の中央に配置するためのオフセット

--- a/src/pages/gacha_hellomegu/script.js
+++ b/src/pages/gacha_hellomegu/script.js
@@ -239,24 +239,6 @@ const displayShareButtonOrTweetLink = (cards) => {
       throw error;
     }
   }
-
-  // TODO: クリップボードにコピーを試してみる
-  document.getElementById("copy-button").onclick = () => {
-    canvas.toBlob((blob) => {
-      const data = [new ClipboardItem({ [blob.type]: blob })];
-
-      navigator.clipboard.write(data).then(
-        () => {
-          /* success */
-          alert('success')
-        },
-        (error) => {
-          /* failure */
-          alert(error)
-        },
-      );
-    });
-  }
 }
 
 /**

--- a/src/pages/gacha_hellomegu/script.js
+++ b/src/pages/gacha_hellomegu/script.js
@@ -70,7 +70,6 @@ const startHellomegGacha = (hellomegImgElement) => {
   descriptionElement.style.display = "none";
   const secretCardContainer = document.getElementById('secret-card-container');
   const cardList = [];
-  const cardColors = [];
 
   // 抽選処理
   for (let i = 0; i < 10; i++) {
@@ -80,68 +79,69 @@ const startHellomegGacha = (hellomegImgElement) => {
     // リンクラと同じく79%でR、18%でSR、3%でURとしている
     if (randomNum < 79) {
       if (i === 9) {
-        cardColors.push('gold');
         hellomegCard = HELLOMEG_SR_CARD_LIST[Math.floor(Math.random() * HELLOMEG_SR_CARD_LIST.length)];
         cardList.push(hellomegCard);
       } else {
-        cardColors.push('cyan');
         hellomegCard = HELLOMEG_R_CARD_LIST[Math.floor(Math.random() * HELLOMEG_R_CARD_LIST.length)];
         cardList.push(hellomegCard);
       }
 
     } else if (randomNum < 97) {
-      cardColors.push('gold');
       hellomegCard = HELLOMEG_SR_CARD_LIST[Math.floor(Math.random() * HELLOMEG_SR_CARD_LIST.length)];
       cardList.push(hellomegCard);
 
     } else {
-      cardColors.push('magenta');
       hellomegCard = HELLOMEG_UR_CARD_LIST[Math.floor(Math.random() * HELLOMEG_UR_CARD_LIST.length)];
       cardList.push(hellomegCard);
     }
   }
 
   const firstImg = document.createElement('div');
-  firstImg.classList.add('image');
-  firstImg.style.backgroundColor = 'cyan';
+  firstImg.classList.add('image', 'first');
   secretCardContainer.appendChild(firstImg);
+
+  // animationDelay 定義
+  const animationDelayBase = 1;
+  const animationDelayRatio = 0.07;
+  const totalAnimationDuration = animationDelayBase + animationDelayRatio * cardList.length;
+
+  // firstImg を一周させる
+  setTimeout(() => {
+    firstImg.classList.add('rotateAroundCircle');
+  }, animationDelayBase * 1000);
+
+  // すべてのカードを描画し終わったら周回完了として非表示にする
+  setTimeout(() => {
+    firstImg.style.display = 'none';
+  }, totalAnimationDuration * 1000);
 
   const radius = 30;
   // カードの円を secretCardContainer の中央に配置するためのオフセット
-  const offsetX = 90;
-  const offsetY = 60;
+  const offset = {
+    x: 90,
+    y: 60,
+  };
 
-  const firstAngle = 0;
-  const x = offsetX + radius * Math.cos(firstAngle);
-  const y = offsetY + radius * Math.sin(firstAngle);
-
-  firstImg.style.left = `${x}px`;
-  firstImg.style.top = `${y}px`;
-  firstImg.style.transform = `rotate(${firstAngle}rad) translate(0, -50%)`;
-  firstImg.style.animationDelay = `0s`;
-
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < cardList.length; i++) {
     const img = document.createElement('div');
-    img.classList.add('image');
-    img.style.backgroundColor = cardColors[i];
+    img.classList.add('image', cardList[i].rarity);
     secretCardContainer.appendChild(img);
 
-    const angle = (i * 36) * (Math.PI / 180);
-    const x = offsetX + radius * Math.cos(angle);
-    const y = offsetY + radius * Math.sin(angle);
+    // 36°の位置からカードを配置するために i + 1 とする
+    const angle = (i + 1) * 36 * (Math.PI / 180);
+    const x = offset.x + radius * Math.cos(angle);
+    const y = offset.y + radius * Math.sin(angle);
 
     img.style.left = `${x}px`;
     img.style.top = `${y}px`;
     img.style.transform = `rotate(${angle}rad) translate(0, -50%)`;
-    img.style.animationDelay = `${i * 0.06 + 1}s`;
+    img.style.animationDelay = `${i * animationDelayRatio + animationDelayBase}s`;
   }
 
-  const totalAnimationDuration = 10 * 0.06 + 1 + 1;
   setTimeout(() => {
     secretCardContainer.style.display = 'none';
     resultCard(cardList);
-  }, totalAnimationDuration * 1000);
-
+  }, (totalAnimationDuration + 1) * 1000);
 };
 
 const resultCard = (cardList) => {

--- a/src/pages/gacha_hellomegu/style.css
+++ b/src/pages/gacha_hellomegu/style.css
@@ -48,6 +48,7 @@
 
 #secret-card-container {
   position: relative;
+  top: -370px;
   width: 300px;
   margin: 0 auto;
 }
@@ -74,7 +75,7 @@
 
 .image.UR {
   background: linear-gradient(to bottom right, #00FFFF, #FF00FF);
-  box-shadow: 0 0 20px 10px magenta;
+  box-shadow: 0 0 20px 10px blueviolet;
 }
 
 .image.first {
@@ -91,7 +92,7 @@
   top: 0px;
   left: 120px;
   opacity: 1;
-  animation: rotateAroundCircle 0.7s linear 1;
+  animation: rotateAroundCircle 1.4s linear 1;
   transform-origin: center 180px;
 }
 
@@ -99,6 +100,10 @@
   0% {
     transform: rotate(0deg);
   }
+  50% {
+    transform: rotate(360deg);
+  }
+  /* 50%-100% は何も変化させない */
   100% {
     transform: rotate(360deg);
   }

--- a/src/pages/gacha_hellomegu/style.css
+++ b/src/pages/gacha_hellomegu/style.css
@@ -58,8 +58,51 @@
   width: 60px;
   height: 120px;
   opacity: 0;
+  border-radius: 2px;
   transform-origin: bottom right;
   animation: fadeIn 1s forwards;
+}
+
+.image.R {
+  background-color: palegoldenrod;
+  box-shadow: 0 0 20px 10px gold;
+}
+
+.image.SR {
+  background-color: paleturquoise;
+  box-shadow: 0 0 20px 10px cyan;
+}
+
+.image.UR {
+  background: linear-gradient(to bottom right, #00FFFF, #FF00FF);
+  box-shadow: 0 0 20px 10px magenta;
+}
+
+.image.first {
+  top: 60px;
+  left: 120px;
+  z-index: 1; /* 他のカードより前面に配置されるようにする */
+  background-color: cyan;
+  box-shadow: 0 0 6px 6px rgba(0, 255, 255, 0.5);
+  transform: rotate(0rad) translate(0, -50%);
+  animation-delay: 0s;
+}
+
+.image.first.rotateAroundCircle {
+  top: 0px;
+  left: 120px;
+  opacity: 1;
+  animation: rotateAroundCircle 0.7s linear 1;
+  transform-origin: center 180px;
+}
+
+@keyframes rotateAroundCircle {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 #container {

--- a/src/pages/gacha_hellomegu/style.css
+++ b/src/pages/gacha_hellomegu/style.css
@@ -49,7 +49,8 @@
 #secret-card-container {
   position: relative;
   height: 400px;
-  width: 200px;
+  width: 300px;
+  margin: 0 auto;
 }
 
 .image {

--- a/src/pages/gacha_hellomegu/style.css
+++ b/src/pages/gacha_hellomegu/style.css
@@ -11,8 +11,13 @@
 }
 
 .modal {
+  position: fixed;
+  inset: 0;
+  margin: auto;
+  max-width: 600px;
+  width: 90%;
+  height: fit-content;
   background-color: #fff;
-  margin: 20% 5% auto 5%;
   border-radius: 10px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }

--- a/src/pages/gacha_hellomegu/style.css
+++ b/src/pages/gacha_hellomegu/style.css
@@ -48,7 +48,6 @@
 
 #secret-card-container {
   position: relative;
-  height: 400px;
   width: 300px;
   margin: 0 auto;
 }
@@ -131,4 +130,8 @@
   to {
     opacity: 1;
   }
+}
+
+#result {
+  margin-top: 2em;;
 }


### PR DESCRIPTION
discord でコメントあった内容に対応する。
> やりたいこと
> ・1枚目画像の色味調整（リンクラっぽいグラデーションとか影を付けたい）
> ・2枚目画像の並びもリンクラ準拠にしたい（少し斜めに並んでて一部カードが重なる表示）
> ・ハロめぐドローみたいにガチャ結果を共有できるようにしたい
> ・SRとURの画像を増やす（新規画像もあるととても嬉しい）
>
> 課題
> ・カードを10枚広げるアニメーションの位置調整（ハロめぐとめちゃくちゃ被っちゃう）