### PR TITLE
modal 本文の色を theme によらす固定する

### DIFF
--- a/src/pages/gacha_hellomegu/style.css
+++ b/src/pages/gacha_hellomegu/style.css
@@ -17,6 +17,7 @@
   max-width: 600px;
   width: 90%;
   height: fit-content;
+  color: #333333;
   background-color: #fff;
   border-radius: 10px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
## 修正内容
kiaiiretekonchikushow はダークテーマに対応している。色定義は global.css で管理される。

https://github.com/mtsml/kiaiiretekonchikushow/blob/4666e67e3d9123fab299e029870e41dc1d83f0d8/src/global.css#L1-L21
https://github.com/mtsml/kiaiiretekonchikushow/blob/4666e67e3d9123fab299e029870e41dc1d83f0d8/src/global.css#L23-L26

今回のモーダルは背景色が white 固定なので、color も固定しておかないとダークテーマのときに文字が見えなくなってしまうので修正した。

## 確認
修正前
<img width="300" alt="スクリーンショット 2024-08-10 11 16 06" src="https://github.com/user-attachments/assets/30f2d81a-9ffc-4346-8203-d8c78126e687">

修正後
<img width="300" alt="スクリーンショット 2024-08-10 11 15 43" src="https://github.com/user-attachments/assets/d28cfcb2-ab49-4e80-a480-725711c9a1e7">
