### PR TITLE
ハロめぐガチャの結果画面にアンケートリンクを追加

### DIFF
--- a/src/pages/gacha/index.html
+++ b/src/pages/gacha/index.html
@@ -136,6 +136,16 @@
           <span>もう10回引く</span>
         </button>
       </p>
+      <p>
+        <a
+          href="https://forms.gle/PJNakEKoMH2NQguaA"
+          target="_blank"
+        >
+          <span>アンケートに答える ※SIsCaはもらえません</span>
+          <!-- UpRightFromSquare Icon -->
+          <svg class="c-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="currentColor" d="M352 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L370.7 96 201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L416 141.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6l0-128c0-17.7-14.3-32-32-32L352 0zM80 32C35.8 32 0 67.8 0 112L0 432c0 44.2 35.8 80 80 80l320 0c44.2 0 80-35.8 80-80l0-112c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 112c0 8.8-7.2 16-16 16L80 448c-8.8 0-16-7.2-16-16l0-320c0-8.8 7.2-16 16-16l112 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L80 32z"/></svg>
+        </a>
+      </p>
     </div>
   </main>
 </body>

--- a/src/pages/gacha/style.css
+++ b/src/pages/gacha/style.css
@@ -115,6 +115,8 @@
 }
 
 #container {
+  margin-top: 0.5em;
+  margin-bottom: 1.5em;
   display: grid;
   grid-template-columns: repeat(5, 1fr);
   gap: 10px;
@@ -194,8 +196,8 @@
   }
 }
 
-#result {
-  margin-top: 2em;;
+#result p {
+  margin-bottom: 0.5em;
 }
 
 .overflow-hidden {


### PR DESCRIPTION
前回 1stTerm 終わりにまとめてアンケートをとったが、ユーザーはその時点でゲームのことなど忘れていると思う。
ゲームをしてすぐにフィードバックできるようにするためにアンケートリンクを追加する。