### PR TITLE
fix: add crossOrigin

### DIFF
--- a/src/pages/gacha/script.js
+++ b/src/pages/gacha/script.js
@@ -298,6 +298,10 @@ const drawCanvas = (cards) => {
       img.onload = () => resolve(img);
       img.onerror = reject;
       img.src = card.src;
+      // 外部画像を描画すると canvas が tainted となり、toBlob が使えなくなるため、crossOrigin を設定する
+      if (!isSameOrigin(card.src)) {
+        img.crossOrigin = "anonymous";
+      }
     });
     const dx = index < 5
       ? padding + (cardWidth + padding) * index        // 1行目
@@ -314,6 +318,20 @@ const drawCanvas = (cards) => {
   });
 
   return canvas;
+}
+
+/**
+ * 指定された URL が現在のページと同一オリジンかどうかを判定する
+ */
+const isSameOrigin = (src) => {
+  try {
+    // src が相対パスの場合は、現在のページの URL を基準にして絶対パスを生成する
+    const url = new URL(src, window.location.href);
+    return url.origin === window.location.origin;
+  } catch (e) {
+    console.error(e);
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

### 背景
https://github.com/mtsml/kiaiiretekonchikushow/pull/104 で外部オリジンの画像を canvas に読み込むように修正したことで、セキュリティ上の制約により tainted 扱いとなり、`toBlob` や `toDataURL` が使用できなくなった

### 修正
画像の URL が現在のページと異なるオリジンである場合に `img.crossOrigin = "anonymous"` を設定する

### 参考
- [MDN: CORS-enabled image](https://developer.mozilla.org/ja/docs/Web/HTML/How_to/CORS_enabled_image)

<!-- I want to review in Japanese. -->